### PR TITLE
make speed control dynamic and number of lookahead waypoints dynamic

### DIFF
--- a/ros/src/waypoint_updater/launch/waypoint_updater.launch
+++ b/ros/src/waypoint_updater/launch/waypoint_updater.launch
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <launch>
     <node pkg="waypoint_updater" type="waypoint_updater.py" name="waypoint_updater" respawn="true">
-        <param name="speed_limit" value="10.0" />
+        <param name="speed_limit" value="11.111" />
     </node>
 </launch>


### PR DESCRIPTION
I refactored the if/elif section to be dynamic based on the number distance to a stop light.  I also added some code to make the number of lookahead waypoints dynamic.  That way when the speed limit is changed, the number of lookahead waypoints is increased to help get the car stopped in time.  I am noticing one issue.  When the car approaches the 3rd stoplight, it doesn't appear to register the distance to the stop light correctly.  If you watch pull my branch and run the simulation, print to the screen when the car is accelerating and also when the car starts braking.  When it approaches the 2nd stop light, the braking occurs at a distance sufficient to stop the car.  When it approaches the 3rd stop light, it gets much closer before it starts to brake.  This causes the car not to be able to stop in time for a red light.  Not sure what is going on with that yet.  I'm going to print out the waypoint information and see if I can determine what is going on.  Meanwhile, I think the changes in this branch are worth getting into master to be further built upon.  You can approve the PR if you agree. :)